### PR TITLE
Linux build ubuntu2204

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ dcamprof if that interests you.
    tags. This is very optional, but does avoid RawTherapee reporting your lens
    as "Unknown".
 
-# Linux build (tested on Ubuntu 20.04):
+## Linux build (tested on Ubuntu 20.04):
 
 In the base directory for the project, build with:
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ dcamprof if that interests you.
    tags. This is very optional, but does avoid RawTherapee reporting your lens
    as "Unknown".
 
-Linux build (tested on Ubuntu 20.04):
+# Linux build (tested on Ubuntu 20.04):
 
 In the base directory for the project, build with:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-makeDNG
-===========
+# makeDNG
 
 Simple tool for converting mosaiced (Bayer) TIFF files to Adobe DNG,
 specifically suited for the Point Grey BFLY-U3-23S6C-C camera.
 
-Usage:
+# Usage:
 
     makeDNG input_tiff_file output_dng_file [cfa_pattern] [compression] [reelname] [frame number]
 cfa_pattern can be from 0-3
@@ -27,7 +26,7 @@ frame number
   The frame number should match the sequencing field of the file name. See §6.2
   of the CinemaDNG spec for details.
 
-Notes:
+# Notes:
 
 Adobe Camera Raw sometimes decodes lossless JPEG files incorrectly, so this is
 why lossless JPEG is not the default. Both RawTherapee 5.5 and ffmpeg decode
@@ -44,10 +43,11 @@ data is estimated from the graphic in the camera's data sheet, so don't put too
 much trust in it.  A trivial patch is needed to add Ektaspace primaries to
 dcamprof if that interests you.
 
-Build Instructions:
+# Build Instructions
 
- * An MSVC project is included. I haven't bothered to test on non-Windows
-   systems, but it should be fairly portable.
+## Windows build (Visual Studio 2017):
+
+ * An MSVC project is included.
  * libtiff newer than around 4.0.6 is required for some of the DNG tags.
    Even when compression is used, no optional libs (zlib/zstd/lzma/libjpeg) are
    needed. We compress each tile with LJ92 ourselves and write them with
@@ -56,13 +56,21 @@ Build Instructions:
    tags. This is very optional, but does avoid RawTherapee reporting your lens
    as "Unknown".
 
-TODO:
+Linux build (tested on Ubuntu 20.04):
+
+In the base directory for the project, build with:
+
+```
+gcc -std=c99 -g -oO *.c -o makedng -lz -ltiff -lm
+```
+
+# TODO:
 
  * Use threads to compress each tile
  * Add support for non-mod16 tile sizes (use padding)
  * Implement the floating point X2 predictor (34894)
 
-References:
+# References:
 
 Thanks to the following for their previous work:
 

--- a/makeDNG.c
+++ b/makeDNG.c
@@ -259,7 +259,18 @@ int main( int argc, char **argv )
     TIFFSetField( tif, TIFFTAG_DATETIME, datetime );
     TIFFSetField( tif, TIFFTAG_SAMPLEFORMAT, sampleformat );
     TIFFSetField( tif, TIFFTAG_CFAREPEATPATTERNDIM, cfa_dimensions );
+
+#if TIFFLIB_VERSION >= 20201219
+    /*
+        The arguments for TIFFTAG_CFAPATTERN changed in tifflib 4.2.0 per
+        https://gitlab.com/libtiff/libtiff/-/issues/58
+        In newer versions we need to specify the number of elements in the pattern array.
+        The number above is TIFFLIB_VERSION in tiffvers.h v4.2.0
+    */
+    TIFFSetField( tif, TIFFTAG_CFAPATTERN, 4, cfa_patterns[cfa] );
+#else
     TIFFSetField( tif, TIFFTAG_CFAPATTERN, cfa_patterns[cfa] );
+#endif
     TIFFSetField( tif, TIFFTAG_UNIQUECAMERAMODEL, "Point Grey Blackfly U3-23S6C-C" );
     TIFFSetField( tif, TIFFTAG_CFAPLANECOLOR, 3, "\00\01\02" ); // RGB
     TIFFSetField( tif, TIFFTAG_CFALAYOUT, 1 ); // rectangular or square (not staggered)


### PR DESCRIPTION
In the README file, I documented how to build on Linux, which turned out to be very straightforward. The only wrinkle is that some C99 constructs are used, so that needs to be specified in the gcc command.

Whilst at it I added some Markdown formatting to the README.

There was a change in ``libtiff`` per [issue 50](https://gitlab.com/libtiff/libtiff/-/issues/58), first present in Version 4.2.0, requiring a new argument when setting the ``TIFFTAG_CFAPATTERN`` field. The code now conditionally compiles with that new argument, when built against libtiff 4.2.0 or newer.